### PR TITLE
Convert all methods to named functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 
-module.exports = function () {
+module.exports = function aJavaScriptPortOfTheUnixUtilityTrueReturnsTheBooleanValueTrue () {
   return true;
 };


### PR DESCRIPTION
Debugging is important, and for such a critical module, I _must have_ the ability to see named functions all the way down the stack.

I recognized that this increases the weight of the module by 66.1441441%, but for such an important step of my debugging flow, I consider it well worth it.

My thanks to @Techwraith for assisting with this patch.
