### PR TITLE
only publish critical files & shorten the function name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-module.exports = function aJavaScriptPortOfTheUnixUtilityTrueReturnsTheBooleanValueTrue () {
+module.exports = function returnTrue() {
   return true;
 };
-

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "true": "bin/cli.js"
   },
+  "files": [
+    "bin",
+    "index.js"
+  ],
   "scripts": {
     "test": "jake test"
   },


### PR DESCRIPTION
The function name seems unnecessarily long, so I changed it to `returnTrue`.

And the NPM tarball will now contain `index.js`, `bin/cli.js`, `README.md`, and `package.json`.